### PR TITLE
feat(events): Enable company mentor event management and fix event creation bugs

### DIFF
--- a/src/app/(dashboard)/dashboard/company/page.tsx
+++ b/src/app/(dashboard)/dashboard/company/page.tsx
@@ -125,6 +125,44 @@ export default function CompanyDashboardPage() {
             </CardContent>
           </Card>
         </Link>
+
+        <Link href="/dashboard/manage-events" className="block group">
+          <Card className="h-full transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center mb-4 group-hover:bg-primary/20 transition-colors">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-6 w-6 text-primary"
+                  role="img"
+                >
+                  <title>Events Icon</title>
+                  <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+                  <line x1="16" x2="16" y1="2" y2="6" />
+                  <line x1="8" x2="8" y1="2" y2="6" />
+                  <line x1="3" x2="21" y1="10" y2="10" />
+                </svg>
+              </div>
+              <CardTitle>Manage Events</CardTitle>
+              <CardDescription>
+                Create and manage company events, track interest, and connect
+                with attendees from the community.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-sm font-medium text-primary flex items-center">
+                View Events →
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
       </div>
     </div>
   );

--- a/src/app/(dashboard)/dashboard/talent-pool/page.tsx
+++ b/src/app/(dashboard)/dashboard/talent-pool/page.tsx
@@ -373,22 +373,21 @@ export default function TalentPoolPage() {
         </p>
       </div>
 
-      {/* Summary strip */}
-      {!isLoading && !isError && (
-        <div className="flex flex-wrap gap-3">
-          <div className="flex items-center gap-2 rounded-xl border border-border bg-card px-4 py-2.5 text-sm">
+      {/* Controls row */}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 w-full">
+        {/* Summary badge */}
+        {!isLoading && !isError && (
+          <div className="flex h-9 shrink-0 items-center gap-2 rounded-xl border border-border bg-card px-4 text-sm">
             <Users className="h-4 w-4 text-primary" />
             <span className="font-semibold text-foreground">
               {total.toLocaleString()}
             </span>
             <span className="text-muted-foreground">learners found</span>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Controls row */}
-      <div className="flex items-center gap-3 flex-wrap">
-        <div className="relative flex-1 min-w-[200px] max-w-sm">
+        {/* Search */}
+        <div className="relative w-full sm:w-[300px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
           <Input
             id="talent-search"
@@ -398,7 +397,7 @@ export default function TalentPoolPage() {
               setPageIndex(1);
             }}
             placeholder="Search by name or MUID…"
-            className="h-9 pl-9 pr-8 text-sm"
+            className="h-9 pl-9 pr-8 text-sm w-full"
           />
           {search && (
             <button
@@ -410,24 +409,28 @@ export default function TalentPoolPage() {
             </button>
           )}
         </div>
-        <FiltersDropdown
-          filters={filters}
-          onChange={(f) => {
-            setFilters(f);
-            setPageIndex(1);
-          }}
-        />
-        {hasActive && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-9 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-            onClick={clearFilters}
-          >
-            <X className="h-3.5 w-3.5" />
-            Clear all
-          </Button>
-        )}
+
+        {/* Filters */}
+        <div className="flex items-center gap-2">
+          <FiltersDropdown
+            filters={filters}
+            onChange={(f) => {
+              setFilters(f);
+              setPageIndex(1);
+            }}
+          />
+          {hasActive && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-9 gap-1.5 text-xs text-muted-foreground hover:text-foreground shrink-0"
+              onClick={clearFilters}
+            >
+              <X className="h-3.5 w-3.5" />
+              Clear all
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Grid */}

--- a/src/features/company-jobs/components/job-card.tsx
+++ b/src/features/company-jobs/components/job-card.tsx
@@ -25,7 +25,7 @@ export function JobCard({ job, onView }: JobCardProps) {
       : "N/A";
 
   return (
-    <div className="group relative rounded-xl border border-border bg-card p-5 transition-all duration-200 hover:border-primary/30 hover:shadow-md hover:shadow-primary/5">
+    <div className="group relative flex h-full flex-col rounded-xl border border-border bg-card p-5 transition-all duration-200 hover:border-primary/30 hover:shadow-md hover:shadow-primary/5">
       {/* Header */}
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
@@ -60,7 +60,7 @@ export function JobCard({ job, onView }: JobCardProps) {
       </div>
 
       {/* Tags */}
-      <div className="mt-3 flex flex-wrap gap-1.5">
+      <div className="mt-3 mb-4 flex flex-1 flex-wrap items-start gap-1.5">
         {job.rules.length > 0 && (
           <Badge variant="outline" className="text-xs">
             {job.rules.length} rule{job.rules.length > 1 ? "s" : ""}
@@ -69,7 +69,7 @@ export function JobCard({ job, onView }: JobCardProps) {
       </div>
 
       {/* Footer */}
-      <div className="mt-4 flex items-center justify-between border-t border-border pt-3">
+      <div className="mt-auto flex items-center justify-between border-t border-border pt-3">
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <Calendar className="h-3 w-3" />
           <span>{formattedDate}</span>

--- a/src/features/company-jobs/components/learner-card.tsx
+++ b/src/features/company-jobs/components/learner-card.tsx
@@ -18,7 +18,7 @@ export function LearnerCard({ learner }: LearnerCardProps) {
     .toUpperCase();
 
   return (
-    <Card className="group relative p-3 py-4">
+    <Card className="group flex h-full flex-col p-3 py-4">
       {/* Avatar + name */}
       <div className="flex items-start gap-3 pr-24">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-sm font-bold text-primary">
@@ -67,7 +67,7 @@ export function LearnerCard({ learner }: LearnerCardProps) {
       </div>
 
       {/* Details */}
-      <div className="mt-3 space-y-1">
+      <div className="mt-3 mb-4 flex-1 space-y-1">
         {learner.college && (
           <div className="flex items-start gap-1.5 text-xs text-muted-foreground">
             <MapPin className="h-3 w-3 shrink-0 mt-0.5" />
@@ -93,7 +93,7 @@ export function LearnerCard({ learner }: LearnerCardProps) {
       </div>
 
       {/* View profile CTA */}
-      <div className="mt-4 border-t border-border pt-3">
+      <div className="mt-auto border-t border-border pt-3">
         <Button
           variant="ghost"
           size="sm"

--- a/src/features/company-jobs/components/profile/company-profile-page.tsx
+++ b/src/features/company-jobs/components/profile/company-profile-page.tsx
@@ -238,24 +238,6 @@ export function CompanyProfilePage() {
         remotePolicy={profile.remote_policy ?? null}
       />
 
-      {/* Stats row */}
-      <div className="grid gap-4 sm:grid-cols-2">
-        <StatCard
-          icon={<FileText className="size-5" />}
-          value={activeJobs.length}
-          label="Open Roles"
-          color="text-success"
-          bg="bg-success/10"
-        />
-        <StatCard
-          icon={<Award className="size-5" />}
-          value={(profile.avg_karma_of_hires ?? 0).toLocaleString()}
-          label="Avg. Hire Karma"
-          color="text-brand-purple"
-          bg="bg-brand-purple/10"
-        />
-      </div>
-
       {/* Two-column layout */}
       <div className="grid gap-5 lg:grid-cols-[300px_1fr]">
         {/* Sidebar */}
@@ -265,6 +247,24 @@ export function CompanyProfilePage() {
 
         {/* Main content */}
         <div className="order-1 space-y-5 lg:order-2">
+          {/* Stats row */}
+          <div className="grid gap-4 sm:grid-cols-2">
+            <StatCard
+              icon={<FileText className="size-5" />}
+              value={activeJobs.length}
+              label="Open Roles"
+              color="text-success"
+              bg="bg-success/10"
+            />
+            <StatCard
+              icon={<Award className="size-5" />}
+              value={(profile.avg_karma_of_hires ?? 0).toLocaleString()}
+              label="Avg. Hire Karma"
+              color="text-brand-purple"
+              bg="bg-brand-purple/10"
+            />
+          </div>
+
           {/* About */}
           {profile.description && (
             <div className="rounded-2xl bg-card p-5 shadow-sm">
@@ -283,19 +283,15 @@ export function CompanyProfilePage() {
             techStack={profile.tech_stack ?? []}
             perks={profile.perks ?? []}
           />
-
-          {/* Jobs */}
-          <CompanyJobsSection
-            isOwnProfile
-            ownJobs={isLoadingJobs ? [] : allJobs}
-          />
-
-          {/* Testimonials */}
-          <CompanyTestimonialsSection
-            testimonials={profile.testimonials ?? []}
-          />
         </div>
       </div>
+
+      {/* Full-width sections below the two-column layout */}
+      {/* Jobs */}
+      <CompanyJobsSection isOwnProfile ownJobs={isLoadingJobs ? [] : allJobs} />
+
+      {/* Testimonials */}
+      <CompanyTestimonialsSection testimonials={profile.testimonials ?? []} />
     </div>
   );
 }

--- a/src/features/company-jobs/components/public-job-card.tsx
+++ b/src/features/company-jobs/components/public-job-card.tsx
@@ -29,7 +29,7 @@ export function PublicJobCard({ job, onView }: PublicJobCardProps) {
     <button
       type="button"
       onClick={() => onView(job)}
-      className="group relative w-full rounded-2xl border border-border bg-card p-5 text-left transition-all duration-200 hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5"
+      className="group relative flex h-full w-full flex-col rounded-2xl border border-border bg-card p-5 text-left transition-all duration-200 hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5"
     >
       {/* Title + meta */}
       <div className="pr-20">
@@ -71,7 +71,7 @@ export function PublicJobCard({ job, onView }: PublicJobCardProps) {
       </div>
 
       {/* Requirement badges — uses semantic CSS variables only */}
-      <div className="mt-3 flex flex-wrap gap-1.5">
+      <div className="mt-3 mb-4 flex flex-1 flex-wrap items-start gap-1.5">
         {/* Empty placeholder if no stipend or cert, since badges are optional now */}
         {job.stipend && (
           <Badge variant="outline" className="text-xs">
@@ -87,7 +87,7 @@ export function PublicJobCard({ job, onView }: PublicJobCardProps) {
       </div>
 
       {/* Footer */}
-      <div className="mt-4 flex items-center justify-between border-t border-border pt-3">
+      <div className="mt-auto flex w-full items-center justify-between border-t border-border pt-3">
         {job.created_at ? (
           <span className="flex items-center gap-1 text-xs text-muted-foreground">
             <Calendar className="h-3 w-3" />

--- a/src/features/events/api/events.api.ts
+++ b/src/features/events/api/events.api.ts
@@ -53,6 +53,27 @@ function mirrorEventTypeToCategory<T extends EventShape>(event: T): T {
   const eventType = event.event_type ?? null;
   const categoryName = event.category_name ?? null;
 
+  // Normalize organizer properties if they use the 'organiser_' prefix
+  // Using 'any' since EventShape does not fully type the organizer field
+  const org = (event as any).organizer;
+  if (org && typeof org === "object") {
+    if (org.type === undefined && org.organiser_type !== undefined) {
+      org.type = org.organiser_type;
+    }
+    if (org.ig === undefined && org.organiser_ig !== undefined) {
+      org.ig = org.organiser_ig;
+    }
+    if (org.campus === undefined && org.organiser_campus !== undefined) {
+      org.campus = org.organiser_campus;
+    }
+    if (org.company === undefined && org.organiser_company !== undefined) {
+      org.company = org.organiser_company;
+    }
+    if (org.campus_ig_id === undefined && org.organiser_ci_id !== undefined) {
+      org.campus_ig_id = org.organiser_ci_id;
+    }
+  }
+
   if (!eventType || categoryName) {
     return event;
   }

--- a/src/features/events/components/event-card.tsx
+++ b/src/features/events/components/event-card.tsx
@@ -18,24 +18,33 @@ interface EventCardProps {
 }
 
 function getOrganizerName(organizer: OrganizerInfo): string {
-  if (organizer.type === "global_ig") {
-    return organizer.ig?.name ?? "Global IG";
+  if (!organizer) return "MuLearn";
+
+  const type = organizer.type ?? organizer.organiser_type;
+
+  if (type === "global_ig") {
+    const igName = organizer.ig?.name ?? organizer.organiser_ig?.name;
+    return igName ?? "Global IG";
   }
-  if (organizer.type === "campus_ig") {
-    const igName = organizer.ig?.name;
-    const campusName = organizer.campus?.title ?? organizer.campus?.name;
+  if (type === "campus_ig") {
+    const igName = organizer.ig?.name ?? organizer.organiser_ig?.name;
+    const campusInfo = organizer.campus ?? organizer.organiser_campus;
+    const campusName = campusInfo?.title ?? campusInfo?.name;
+
     if (igName && campusName) {
       return `${igName} @ ${campusName}`;
     }
     return organizer.campus_ig?.name ?? "Campus IG";
   }
-  if (organizer.type === "campus") {
-    return organizer.campus?.title ?? organizer.campus?.name ?? "Campus";
+  if (type === "campus") {
+    const campusInfo = organizer.campus ?? organizer.organiser_campus;
+    return campusInfo?.title ?? campusInfo?.name ?? "Campus";
   }
-  if (organizer.type === "company") {
-    return organizer.company?.title ?? organizer.company?.name ?? "Company";
+  if (type === "company") {
+    const companyInfo = organizer.company ?? organizer.organiser_company;
+    return companyInfo?.title ?? companyInfo?.name ?? "Company";
   }
-  if (organizer.type === "admin") {
+  if (type === "admin") {
     return "MuLearn";
   }
   return "MuLearn";

--- a/src/features/events/components/event-create-wizard.tsx
+++ b/src/features/events/components/event-create-wizard.tsx
@@ -23,6 +23,7 @@ import {
   EVENT_CREATE_WIZARD_STEPS,
   EVENT_FORM_DEFAULT_VALUES,
   EVENT_SCOPE_OPTIONS,
+  EVENT_CLUSTER_OPTIONS,
 } from "../constants/events.constants";
 import {
   toEventFormData,
@@ -290,7 +291,7 @@ export function EventCreateWizard({ open, onClose }: EventCreateWizardProps) {
 
   const validateCurrentStep = async (): Promise<boolean> => {
     if (currentStep === 1) {
-      return trigger(["title", "description"]);
+      return trigger(["title", "description", "event_scope"]);
     }
 
     if (currentStep === 2) {
@@ -460,6 +461,7 @@ export function EventCreateWizard({ open, onClose }: EventCreateWizardProps) {
       venue_maps_url: values.maps_url,
       venue_online_link: values.online_link,
       venue_platform: values.platform,
+      event_scope: values.event_scope,
       scope: values.scope,
       scope_org: values.scope === "campus" ? values.target_campus_id : null,
       scope_ig: values.scope === "ig" ? values.target_ig_id : null,
@@ -637,6 +639,43 @@ export function EventCreateWizard({ open, onClose }: EventCreateWizardProps) {
                       </p>
                     ) : null}
                   </div>
+
+                  <div className="space-y-2">
+                    <p className="text-sm font-medium text-foreground">
+                      Event Cluster / Category{" "}
+                      <span className="text-destructive">*</span>
+                    </p>
+                    <Controller
+                      control={control}
+                      name="event_scope"
+                      render={({ field }) => (
+                        <div className="flex flex-wrap gap-2">
+                          {EVENT_CLUSTER_OPTIONS.filter(
+                            (o) => o.value !== "all",
+                          ).map((item) => {
+                            const active = field.value === item.value;
+                            return (
+                              <Button
+                                key={item.value}
+                                type="button"
+                                variant={active ? "default" : "outline"}
+                                size="sm"
+                                onClick={() => field.onChange(item.value)}
+                              >
+                                {item.label}
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    />
+                    {errors.event_scope?.message ? (
+                      <p className="text-xs text-destructive">
+                        {errors.event_scope.message}
+                      </p>
+                    ) : null}
+                  </div>
+
                   <div className="space-y-2">
                     <p className="text-sm font-medium text-foreground">Tags</p>
                     <div className="flex gap-2">

--- a/src/features/events/components/event-detail-view.tsx
+++ b/src/features/events/components/event-detail-view.tsx
@@ -18,20 +18,30 @@ export function EventDetailView({
   showInterestButton = true,
   layout = "full",
   showVenue = true,
+  initialEvent,
 }: EventDetailViewProps) {
-  const { data: event, isLoading, isError, error } = useEventDetail(eventId);
+  const {
+    data: fetchedEvent,
+    isLoading,
+    isError,
+    error,
+  } = useEventDetail(initialEvent ? undefined : eventId);
 
-  if (isLoading) {
+  const event = initialEvent ?? fetchedEvent;
+
+  if (isLoading && !initialEvent) {
     return <EventDetailSkeleton />;
   }
 
-  if (isError || !event) {
+  if ((isError || !event) && !initialEvent) {
     return (
       <p className="text-sm text-destructive">
         {error instanceof Error ? error.message : "Failed to load event"}
       </p>
     );
   }
+
+  if (!event) return null;
 
   const organizerName = (() => {
     const { type, ig, campus, company, campus_ig } = event.organizer;

--- a/src/features/events/components/event-search.tsx
+++ b/src/features/events/components/event-search.tsx
@@ -61,12 +61,20 @@ function normalizeScopeTargets(
   data: unknown,
   type: CollaboratorType,
 ): CollaborationTarget[] {
-  const paginated = data as { data?: unknown[] } | null;
+  const paginated = data as {
+    data?: unknown[];
+    interestGroup?: unknown[];
+    colleges?: unknown[];
+  } | null;
   const items = Array.isArray(paginated?.data)
-    ? paginated.data
-    : Array.isArray(data)
-      ? data
-      : [];
+    ? paginated!.data!
+    : Array.isArray(paginated?.interestGroup)
+      ? paginated!.interestGroup!
+      : Array.isArray(paginated?.colleges)
+        ? paginated!.colleges!
+        : Array.isArray(data)
+          ? data
+          : [];
 
   const uniqueTargets = new Map<string, CollaborationTarget>();
 

--- a/src/features/events/components/events-grid.tsx
+++ b/src/features/events/components/events-grid.tsx
@@ -9,6 +9,8 @@ interface EventsGridProps {
   onEventDeleted?: () => void;
   onEventView?: (event: EventListItem) => void;
   onCreateEvent?: () => void;
+  emptyTitle?: string;
+  emptyDescription?: string;
 }
 
 export function EventsGrid({
@@ -17,6 +19,8 @@ export function EventsGrid({
   onEventDeleted,
   onEventView,
   onCreateEvent,
+  emptyTitle,
+  emptyDescription,
 }: EventsGridProps) {
   if (events.length === 0) {
     return (
@@ -25,12 +29,14 @@ export function EventsGrid({
           <CalendarPlus2 className="h-5 w-5 text-muted-foreground" />
         </div>
         <p className="text-base font-medium text-foreground">
-          {isManageView ? "No events yet" : "No matching events"}
+          {emptyTitle ??
+            (isManageView ? "No events yet" : "No matching events")}
         </p>
         <p className="mt-1 text-sm text-muted-foreground">
-          {isManageView
-            ? "Create your first event to get your dashboard rolling."
-            : "Try adjusting search or filters to find more events."}
+          {emptyDescription ??
+            (isManageView
+              ? "Create your first event to get your dashboard rolling."
+              : "Try adjusting search or filters to find more events.")}
         </p>
         {isManageView && onCreateEvent ? (
           <Button

--- a/src/features/events/components/manage-event-detail-view.tsx
+++ b/src/features/events/components/manage-event-detail-view.tsx
@@ -308,40 +308,42 @@ export function ManageEventDetailView({
             <ArrowLeft className="mr-2 h-4 w-4" /> Back
           </Button>
 
-          <div className="hidden flex-wrap gap-2 sm:flex">
-            {!isEditing ? (
-              <>
-                <Button
-                  variant="outline"
-                  onClick={() => setPeoplePanelOpen((value) => !value)}
-                >
-                  {peoplePanelOpen ? "Hide People" : "People"}
-                </Button>
-                <Button variant="outline" onClick={enterEditMode}>
-                  <Pencil className="mr-2 h-4 w-4" /> Edit
-                </Button>
-                <Button
-                  variant="destructive"
-                  onClick={() => setConfirmCancelOpen(true)}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" /> Cancel Event
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button
-                  type="submit"
-                  form={`event-inline-edit-form-${event.id}`}
-                  disabled={!isEditSaveArmed}
-                >
-                  Save Changes
-                </Button>
-                <Button variant="outline" onClick={handleDiscard}>
-                  Discard
-                </Button>
-              </>
-            )}
-          </div>
+          {event.status !== "cancelled" && (
+            <div className="hidden flex-wrap gap-2 sm:flex">
+              {!isEditing ? (
+                <>
+                  <Button
+                    variant="outline"
+                    onClick={() => setPeoplePanelOpen((value) => !value)}
+                  >
+                    {peoplePanelOpen ? "Hide People" : "People"}
+                  </Button>
+                  <Button variant="outline" onClick={enterEditMode}>
+                    <Pencil className="mr-2 h-4 w-4" /> Edit
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    onClick={() => setConfirmCancelOpen(true)}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Cancel Event
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    type="submit"
+                    form={`event-inline-edit-form-${event.id}`}
+                    disabled={!isEditSaveArmed}
+                  >
+                    Save Changes
+                  </Button>
+                  <Button variant="outline" onClick={handleDiscard}>
+                    Discard
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -406,6 +408,7 @@ export function ManageEventDetailView({
           ) : (
             <EventDetailView
               eventId={eventId}
+              initialEvent={event}
               showInterestButton={false}
               layout="content-only"
               showVenue={false}
@@ -456,43 +459,45 @@ export function ManageEventDetailView({
         </div>
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 p-3 backdrop-blur sm:hidden">
-        <div className="mx-auto grid max-w-7xl grid-cols-1 gap-2">
-          {!isEditing ? (
-            <Button variant="outline" onClick={enterEditMode}>
-              <Pencil className="mr-2 h-4 w-4" /> Edit
+      {event.status !== "cancelled" && (
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 p-3 backdrop-blur sm:hidden">
+          <div className="mx-auto grid max-w-7xl grid-cols-1 gap-2">
+            {!isEditing ? (
+              <Button variant="outline" onClick={enterEditMode}>
+                <Pencil className="mr-2 h-4 w-4" /> Edit
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type="submit"
+                  form={`event-inline-edit-form-${event.id}`}
+                  disabled={!isEditSaveArmed}
+                >
+                  Save Changes
+                </Button>
+                <Button variant="outline" onClick={handleDiscard}>
+                  Discard
+                </Button>
+              </>
+            )}
+            <Button
+              variant="outline"
+              onClick={() => setPeoplePanelOpen((value) => !value)}
+            >
+              {peoplePanelOpen ? "Hide People" : "People"}
             </Button>
-          ) : (
-            <>
-              <Button
-                type="submit"
-                form={`event-inline-edit-form-${event.id}`}
-                disabled={!isEditSaveArmed}
-              >
-                Save Changes
-              </Button>
-              <Button variant="outline" onClick={handleDiscard}>
-                Discard
-              </Button>
-            </>
-          )}
-          <Button
-            variant="outline"
-            onClick={() => setPeoplePanelOpen((value) => !value)}
-          >
-            {peoplePanelOpen ? "Hide People" : "People"}
-          </Button>
-          <Button variant="outline" onClick={() => setPanelOpen(true)}>
-            Panels
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={() => setConfirmCancelOpen(true)}
-          >
-            Cancel
-          </Button>
+            <Button variant="outline" onClick={() => setPanelOpen(true)}>
+              Panels
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => setConfirmCancelOpen(true)}
+            >
+              Cancel
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
 
       <Sheet open={panelOpen} onOpenChange={setPanelOpen}>
         <SheetContent

--- a/src/features/events/components/manage-events-dashboard.tsx
+++ b/src/features/events/components/manage-events-dashboard.tsx
@@ -255,19 +255,22 @@ export default function ManageEventsDashboard() {
         </p>
       ) : (
         <>
-          {events.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              {canAdminView
-                ? "No events found. If you expected to see events created by other admins, ensure you have been added as a co-owner or contact a platform admin."
-                : "No events found. Create your first event to get started."}
-            </p>
-          ) : null}
           <EventsGrid
             events={events}
             isManageView
             onEventDeleted={handleEventDeleted}
             onCreateEvent={handleCreateEvent}
             onEventView={handleEventView}
+            emptyTitle={
+              totalCount === 0 ? "No events yet" : "No matching events"
+            }
+            emptyDescription={
+              totalCount === 0
+                ? canAdminView
+                  ? "No events found. If you expected to see events created by other admins, ensure you have been added as a co-owner or contact a platform admin."
+                  : "Create your first event to get your dashboard rolling."
+                : "No events match the current filters. Try selecting a different status or adjusting your search."
+            }
           />
           <EventsPagination
             pagination={data?.pagination}

--- a/src/features/events/constants/events.constants.ts
+++ b/src/features/events/constants/events.constants.ts
@@ -184,6 +184,7 @@ export const MANAGE_EVENT_STATUS_PILLS: Array<
 export const EVENT_FORM_DEFAULT_VALUES: CreateEventSchema = {
   title: "",
   description: "",
+  event_scope: "coder",
 
   scope: "global",
   start_datetime: "",

--- a/src/features/events/schemas/events.schema.ts
+++ b/src/features/events/schemas/events.schema.ts
@@ -11,6 +11,7 @@ export const venueTypeSchema = z.enum(["physical", "online", "hybrid"]);
 const createEventBaseSchema = z.object({
   title: z.string().min(1, "Title is required").max(200, "Title too long"),
   description: z.string().min(1, "Description is required"),
+  event_scope: z.enum(["coder", "maker", "manager", "creative"]),
   scope: z.enum(["global", "campus", "ig", "campus_ig"]),
   start_datetime: z
     .string()

--- a/src/features/events/types/events.types.ts
+++ b/src/features/events/types/events.types.ts
@@ -406,6 +406,7 @@ export interface EventWriteBody {
   is_featured?: boolean;
   tags: string[] | null;
   user_limit?: number;
+  event_scope: IGCluster;
 }
 
 export type EventPatchBody = Partial<EventWriteBody>;
@@ -458,6 +459,7 @@ export interface EventDetailViewProps {
   showInterestButton?: boolean;
   layout?: "full" | "content-only";
   showVenue?: boolean;
+  initialEvent?: EventDetail;
 }
 
 export interface ManageEventDetailViewProps {

--- a/src/features/events/types/events.types.ts
+++ b/src/features/events/types/events.types.ts
@@ -133,11 +133,17 @@ export interface MinimalCompany {
 // ─── ORGANIZER INFO ─────────────────────────────────────────────────────────
 
 export interface OrganizerInfo {
-  type: OrganizerType;
+  type?: OrganizerType;
   ig?: MinimalIG | null;
   campus?: MinimalCampus | null;
   company?: MinimalCompany | null;
   campus_ig_id?: UUID | null;
+  // Backend API returns these fields instead
+  organiser_type?: OrganizerType;
+  organiser_ig?: MinimalIG | null;
+  organiser_campus?: MinimalCampus | null;
+  organiser_company?: MinimalCompany | null;
+  organiser_ci_id?: UUID | null;
   // Backward compatibility for old component usage
   campus_ig?: { id: UUID; name: string; icon: string; code?: string } | null;
 }


### PR DESCRIPTION

<img width="1536" height="729" alt="image" src="https://github.com/user-attachments/assets/d5043887-1b87-429b-b72c-cc12e8c8b101" />

### Description

This PR introduces necessary features to allow Company Mentors to properly view and manage events for their respective companies, while fixing several critical bugs in the event creation and display flows.

#### 🚀 Features & Enhancements
* *Company Mentor Event Visibility:* 
  * Updated ManageEventsDashboard to identify COMPANY_MENTOR users using the mentor profile hook.
  * Dynamically passes the mentor's company_id to the API filters so company mentors can view events created by their company.
  * Updated API layer (events.api.ts) and query types to cleanly support company_id filtering.

#### 🐛 Bug Fixes
* *Interest Group (IG) Search Autocomplete:* 
  * Fixed an issue in EventSearch (event-search.tsx) where typing 2+ characters returned "No results found". 
  * The frontend was looking for a .data array, but the backend was returning .interestGroup and .colleges. Updated normalizeScopeTargets to handle these specific response properties properly.
* *Company Event Organizer Display:*
  * Fixed a bug where events created by a company displayed "By MuLearn" instead of the company's name on the EventCard.
  * The API was returning organizer info with an organiser_ prefix (e.g., organiser_type, organiser_company) instead of standard fields.
  * *Fix Details:* 
    1. Added a normalizer in events.api.ts (mirrorEventTypeToCategory) to map organiser_ properties to their standard frontend equivalents at the API boundary.
    2. Updated OrganizerInfo types in events.types.ts to strictly support both formats.
    3. Updated EventCard to correctly parse and render the company title (e.g., "By The Base").