### PR TITLE
feat(jobs): add sort & pagination to Browse Jobs tab& fix Browse Jobs pagination never showing Next button

### DIFF
--- a/src/app/(dashboard)/dashboard/jobs/jobs-page-client.tsx
+++ b/src/app/(dashboard)/dashboard/jobs/jobs-page-client.tsx
@@ -2,6 +2,7 @@
 
 import {
   AlertTriangle,
+  ArrowDownUp,
   Briefcase,
   FileText,
   Filter,
@@ -76,11 +77,27 @@ const APP_SKELETONS = ["app-s1", "app-s2", "app-s3", "app-s4", "app-s5"];
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
+// ─── Sort option definitions ──────────────────────────────────────────────────
+
+const JOB_SORT_OPTIONS = [
+  { value: "-created_at", label: "Newest First" },
+  { value: "created_at", label: "Oldest First" },
+  { value: "title", label: "Title (A → Z)" },
+  { value: "-title", label: "Title (Z → A)" },
+] as const;
+
+const APP_SORT_OPTIONS = [
+  { value: "-appliedAt", label: "Newest First" },
+  { value: "appliedAt", label: "Oldest First" },
+] as const;
+
 export function LearnerJobsPageClient() {
   const [tab, setTab] = useState<"browse" | "applications">("browse");
   const [search, setSearch] = useState("");
+  const [jobPageIndex, setJobPageIndex] = useState(1);
   const [pageIndex, setPageIndex] = useState(1);
-  const [sortBy, setSortBy] = useState<string>("-appliedAt");
+  const [jobSortBy, setJobSortBy] = useState<string>("-created_at");
+  const [appSortBy, setAppSortBy] = useState<string>("-appliedAt");
   const [selectedJob, setSelectedJob] = useState<PublicJob | null>(null);
   const debouncedSearch = useDebounce(search, 300);
 
@@ -88,7 +105,12 @@ export function LearnerJobsPageClient() {
     data: publicJobsData,
     isLoading: loadingJobs,
     isError: jobsError,
-  } = usePublicJobs({ search: debouncedSearch || undefined, perPage: 20 });
+  } = usePublicJobs({
+    search: debouncedSearch || undefined,
+    perPage: 21,
+    pageIndex: jobPageIndex,
+    sortBy: jobSortBy,
+  });
 
   const {
     data: applicationsData,
@@ -97,7 +119,7 @@ export function LearnerJobsPageClient() {
   } = useLearnerApplications({
     search: debouncedSearch || undefined,
     perPage: 30,
-    sortBy: sortBy,
+    sortBy: appSortBy,
     pageIndex: pageIndex,
   });
 
@@ -143,39 +165,77 @@ export function LearnerJobsPageClient() {
           </TabsList>
 
           <div className="flex items-center gap-2">
-            {/* Sort Dropdown (only visible on applications tab) */}
+            {/* Sort Dropdown — Browse Jobs */}
+            {tab === "browse" && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="default"
+                    id="browse-jobs-sort-trigger"
+                    className="gap-2 text-sm"
+                  >
+                    <ArrowDownUp className="h-3.5 w-3.5" />
+                    Sort
+                    <span className="ml-1 hidden rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary sm:inline">
+                      {JOB_SORT_OPTIONS.find((o) => o.value === jobSortBy)
+                        ?.label ?? ""}
+                    </span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[160px]">
+                  <DropdownMenuRadioGroup
+                    value={jobSortBy}
+                    onValueChange={(v) => {
+                      setJobSortBy(v);
+                      setJobPageIndex(1);
+                    }}
+                  >
+                    {JOB_SORT_OPTIONS.map((opt) => (
+                      <DropdownMenuRadioItem
+                        key={opt.value}
+                        value={opt.value}
+                        className="text-xs"
+                      >
+                        {opt.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+
+            {/* Sort Dropdown — My Applications */}
             {tab === "applications" && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="outline"
                     size="default"
+                    id="applications-sort-trigger"
                     className="gap-2 text-sm"
                   >
-                    <Filter className="h-3.5 w-3.5" />
+                    <ArrowDownUp className="h-3.5 w-3.5" />
                     Sort
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
+                <DropdownMenuContent align="end" className="min-w-[140px]">
                   <DropdownMenuRadioGroup
-                    value={sortBy}
+                    value={appSortBy}
                     onValueChange={(v) => {
-                      setSortBy(v);
+                      setAppSortBy(v);
                       setPageIndex(1);
                     }}
                   >
-                    <DropdownMenuRadioItem
-                      value="-appliedAt"
-                      className="text-xs"
-                    >
-                      Newest First
-                    </DropdownMenuRadioItem>
-                    <DropdownMenuRadioItem
-                      value="appliedAt"
-                      className="text-xs"
-                    >
-                      Oldest First
-                    </DropdownMenuRadioItem>
+                    {APP_SORT_OPTIONS.map((opt) => (
+                      <DropdownMenuRadioItem
+                        key={opt.value}
+                        value={opt.value}
+                        className="text-xs"
+                      >
+                        {opt.label}
+                      </DropdownMenuRadioItem>
+                    ))}
                   </DropdownMenuRadioGroup>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -189,6 +249,7 @@ export function LearnerJobsPageClient() {
                 value={search}
                 onChange={(e) => {
                   setSearch(e.target.value);
+                  setJobPageIndex(1);
                   setPageIndex(1);
                 }}
                 placeholder={
@@ -235,11 +296,46 @@ export function LearnerJobsPageClient() {
               }
             />
           ) : (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {jobs.map((job) => (
-                <PublicJobCard key={job.id} job={job} onView={setSelectedJob} />
-              ))}
-            </div>
+            <>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {jobs.map((job) => (
+                  <PublicJobCard
+                    key={job.id}
+                    job={job}
+                    onView={setSelectedJob}
+                  />
+                ))}
+              </div>
+
+              {/* Pagination */}
+              {publicJobsData?.pagination.totalPages &&
+                publicJobsData.pagination.totalPages > 1 && (
+                  <div className="flex justify-between items-center mt-4">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setJobPageIndex((p) => Math.max(1, p - 1))}
+                      disabled={jobPageIndex === 1}
+                      className="h-8 text-xs"
+                    >
+                      Previous
+                    </Button>
+                    <span className="text-xs text-muted-foreground">
+                      Page {jobPageIndex} of{" "}
+                      {publicJobsData.pagination.totalPages}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setJobPageIndex((p) => p + 1)}
+                      disabled={!publicJobsData.pagination.isNext}
+                      className="h-8 text-xs"
+                    >
+                      Next
+                    </Button>
+                  </div>
+                )}
+            </>
           )}
         </TabsContent>
 

--- a/src/app/(dashboard)/dashboard/jobs/jobs-page-client.tsx
+++ b/src/app/(dashboard)/dashboard/jobs/jobs-page-client.tsx
@@ -126,7 +126,11 @@ export function LearnerJobsPageClient() {
   const jobs = publicJobsData?.jobs ?? [];
   const applications = applicationsData?.applications ?? [];
 
-  const handleSearchClear = useCallback(() => setSearch(""), []);
+  const handleSearchClear = useCallback(() => {
+    setSearch("");
+    setJobPageIndex(1);
+    setPageIndex(1);
+  }, []);
 
   return (
     <div className="space-y-6 p-1">

--- a/src/features/company-jobs/schemas/jobs.schema.ts
+++ b/src/features/company-jobs/schemas/jobs.schema.ts
@@ -380,18 +380,15 @@ export const PublicJobsResponseSchema = DjangoResponse(
             .number()
             .nullish()
             .transform((v) => v ?? 0),
-          total_pages: z
-            .number()
-            .nullish()
-            .transform((v) => v ?? 1),
-          current_page: z
-            .number()
-            .nullish()
-            .transform((v) => v ?? 1),
-          per_page: z
-            .number()
-            .nullish()
-            .transform((v) => v ?? 10),
+          // camelCase (new API shape)
+          totalPages: z.number().nullish(),
+          isNext: z.boolean().nullish(),
+          isPrev: z.boolean().nullish(),
+          nextPage: z.number().nullish(),
+          // snake_case (old API shape — kept for backwards compat)
+          total_pages: z.number().nullish(),
+          current_page: z.number().nullish(),
+          per_page: z.number().nullish(),
           next: z.string().nullable().optional(),
           previous: z.string().nullable().optional(),
         })
@@ -399,15 +396,21 @@ export const PublicJobsResponseSchema = DjangoResponse(
         .optional()
         .transform((v) => ({
           count: v?.count ?? 0,
-          totalPages: v?.total_pages ?? 1,
-          isNext: !!v?.next,
-          isPrev: !!v?.previous,
-          nextPage: v?.next ? (v.current_page ?? 1) + 1 : null,
+          totalPages: v?.totalPages ?? v?.total_pages ?? 1,
+          isNext: v?.isNext ?? !!v?.next,
+          isPrev: v?.isPrev ?? !!v?.previous,
+          nextPage: v?.nextPage ?? (v?.next ? (v.current_page ?? 1) + 1 : null),
         })),
     })
     .transform((val) => ({
       jobs: val.jobs ?? val.data ?? [],
-      pagination: val.pagination,
+      pagination: val.pagination ?? {
+        count: 0,
+        totalPages: 1,
+        isNext: false,
+        isPrev: false,
+        nextPage: null,
+      },
     })),
 );
 


### PR DESCRIPTION

<img width="1536" height="726" alt="image" src="https://github.com/user-attachments/assets/d7430dd2-6f2d-4730-b8ca-90c77b5ab51e" />

feat(jobs): add sort & pagination to Browse Jobs tab

- Add sort dropdown to Browse Jobs with options: Newest First,
  Oldest First, Title A→Z, Title Z→A (server-driven via sortBy param)
- Refactor My Applications sort into its own appSortBy state
  (decoupled from Browse Jobs state)
- Change Browse Jobs perPage from 20 → 21 (fills 3-col grid evenly)
- Add dedicated jobPageIndex state and Previous/Next pagination UI
  to Browse Jobs tab; pagination only renders when totalPages > 1
- Reset jobPageIndex to 1 on search or sort change

fix(jobs): fix Browse Jobs pagination never showing Next button

- PublicJobsResponseSchema was built for old snake_case pagination
  shape (total_pages, next/previous as URL strings); the API now
  sends camelCase fields (totalPages, isNext, isPrev, nextPage)
- isNext was always false because !!v?.next was always !!undefined;
  update transform to prefer new camelCase fields with snake_case
  fallback for backwards compatibility
- Remove redundant `?? false` after `!!` expressions (TS2881:
  expression is never nullish)
