### PR TITLE
fix: align card headers side-by-side & resolve calendar API schema mismatch

### DIFF
--- a/src/components/ui/markdown-editor.tsx
+++ b/src/components/ui/markdown-editor.tsx
@@ -13,7 +13,7 @@ import {
   Quote,
   Strikethrough,
 } from "lucide-react";
-import { useCallback, useRef, useState, type KeyboardEvent } from "react";
+import { type KeyboardEvent, useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
 import { MarkdownRenderer } from "./markdown-renderer";

--- a/src/features/company-jobs/api/calendar.api.ts
+++ b/src/features/company-jobs/api/calendar.api.ts
@@ -31,7 +31,7 @@ export const CalendarSessionItemSchema = z.object({
   id: z.string(),
   title: z.string(),
   description: z.string().nullable().optional(),
-  mode: z.string().optional(),
+  mode: z.string().nullable().optional(),
   starts_at: z.string(),
   ends_at: z.string(),
   status: z
@@ -39,7 +39,7 @@ export const CalendarSessionItemSchema = z.object({
     .or(z.string()),
   meeting_link: z.string().nullable().optional(),
   venue: z.string().nullable().optional(),
-  mentor_name: z.string().optional(),
+  mentor_name: z.string().nullable().optional(),
   mentee_count: z.coerce.number().default(0),
 });
 export type CalendarSessionItem = z.infer<typeof CalendarSessionItemSchema>;

--- a/src/features/home/components/campus/circle-health-card.tsx
+++ b/src/features/home/components/campus/circle-health-card.tsx
@@ -31,7 +31,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
       <CardContent className="px-5 pb-5 pt-0">
         {isLoading ? (
           <div className="space-y-3">
-            {[0, 1, 2, 3, 4].map((i) => (
+            {[0, 1, 2].map((i) => (
               <div key={i} className="flex items-center justify-between">
                 <div className="space-y-1">
                   <Skeleton className="h-4 w-36 rounded" />
@@ -42,7 +42,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
             ))}
           </div>
         ) : (
-          <div className="space-y-0 max-h-[340px] overflow-y-auto pr-1">
+          <div className="space-y-0 max-h-[196px] overflow-y-auto pr-1">
             {(items ?? []).map((item) => (
               <div
                 key={item.circle_id}

--- a/src/features/home/components/campus/circle-health-card.tsx
+++ b/src/features/home/components/campus/circle-health-card.tsx
@@ -42,7 +42,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
             ))}
           </div>
         ) : (
-          <div className="space-y-0">
+          <div className="space-y-0 max-h-[340px] overflow-y-auto pr-1">
             {(items ?? []).map((item) => (
               <div
                 key={item.circle_id}
@@ -50,7 +50,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
               >
                 <div>
                   <p className="text-sm font-semibold text-foreground">
-                    {item.circle_name}
+                    {(item.circle_name || "").trim() || "Unnamed Circle"}
                   </p>
                   <p className="text-[11px] text-muted-foreground">
                     {item.member_count} members · {item.sessions_per_month}{" "}

--- a/src/features/home/components/campus/circle-health-card.tsx
+++ b/src/features/home/components/campus/circle-health-card.tsx
@@ -20,18 +20,20 @@ const STATUS_STYLES: Record<CircleHealthStatus, string> = {
 export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
   return (
     <Card className="h-full rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-success/10">
-          <Activity className="size-4 text-success" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-success/10">
+            <Activity className="size-4 text-success" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            Circle Health
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          Circle Health
-        </CardTitle>
       </CardHeader>
       <CardContent className="px-5 pb-5 pt-0">
         {isLoading ? (
           <div className="space-y-3">
-            {[0, 1, 2, 3, 4].map((i) => (
+            {[0, 1, 2].map((i) => (
               <div key={i} className="flex items-center justify-between">
                 <div className="space-y-1">
                   <Skeleton className="h-4 w-36 rounded" />
@@ -42,7 +44,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
             ))}
           </div>
         ) : (
-          <div className="space-y-0 max-h-[340px] overflow-y-auto pr-1">
+          <div className="space-y-0 max-h-[196px] overflow-y-auto pr-1">
             {(items ?? []).map((item) => (
               <div
                 key={item.circle_id}

--- a/src/features/home/components/campus/circle-health-card.tsx
+++ b/src/features/home/components/campus/circle-health-card.tsx
@@ -20,7 +20,7 @@ const STATUS_STYLES: Record<CircleHealthStatus, string> = {
 export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
   return (
     <Card className="h-full rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="px-5 py-4">
+      <CardHeader className="px-5 pt-3 pb-2">
         <div className="flex flex-row items-center gap-2.5">
           <div className="flex size-9 items-center justify-center rounded-xl bg-success/10">
             <Activity className="size-4 text-success" />
@@ -30,7 +30,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
           </CardTitle>
         </div>
       </CardHeader>
-      <CardContent className="px-5 pb-5 pt-0">
+      <CardContent className="px-5 pb-3 pt-0">
         {isLoading ? (
           <div className="space-y-3">
             {[0, 1, 2].map((i) => (
@@ -44,7 +44,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
             ))}
           </div>
         ) : (
-          <div className="space-y-0 max-h-[196px] overflow-y-auto pr-1">
+          <div className="space-y-0 max-h-[240px] overflow-y-auto pr-1">
             {(items ?? []).map((item) => (
               <div
                 key={item.circle_id}
@@ -52,7 +52,7 @@ export function CircleHealthCard({ items, isLoading }: CircleHealthCardProps) {
               >
                 <div>
                   <p className="text-sm font-semibold text-foreground">
-                    {(item.circle_name || "").trim() || "Unnamed Circle"}
+                    {item.circle_name}
                   </p>
                   <p className="text-[11px] text-muted-foreground">
                     {item.member_count} members · {item.sessions_per_month}{" "}

--- a/src/features/home/components/campus/member-funnel-card.tsx
+++ b/src/features/home/components/campus/member-funnel-card.tsx
@@ -50,13 +50,15 @@ export function MemberFunnelCard({
 }: MemberFunnelCardProps) {
   return (
     <Card className="h-full rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
-          <BarChart3 className="size-4 text-warning" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
+            <BarChart3 className="size-4 text-warning" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            Member Funnel
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          Member Funnel
-        </CardTitle>
       </CardHeader>
       <CardContent className="px-5 pb-5 pt-0">
         {campusLabel && (

--- a/src/features/home/components/campus/recent-activity-card.tsx
+++ b/src/features/home/components/campus/recent-activity-card.tsx
@@ -29,13 +29,15 @@ function timeAgo(isoDate: string): string {
 export function RecentActivityCard({ items, isLoading }: Props) {
   return (
     <Card className="rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10">
-          <Zap className="size-4 text-primary" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10">
+            <Zap className="size-4 text-primary" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            Recent Campus Activity
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          Recent Campus Activity
-        </CardTitle>
       </CardHeader>
       <CardContent className="px-5 pb-5 pt-0">
         {isLoading ? (

--- a/src/features/home/components/campus/top-students-card.tsx
+++ b/src/features/home/components/campus/top-students-card.tsx
@@ -33,13 +33,15 @@ export function TopStudentsCard({
   const visible = items.slice(0, 8);
   return (
     <Card className="rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
-          <Star className="size-4 text-warning" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
+            <Star className="size-4 text-warning" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            Top Students{campusName ? ` — ${campusName}` : ""}
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          Top Students{campusName ? ` — ${campusName}` : ""}
-        </CardTitle>
       </CardHeader>
       <CardContent className="px-5 pb-5 pt-0">
         {isLoading ? (

--- a/src/features/home/components/mentor-home.tsx
+++ b/src/features/home/components/mentor-home.tsx
@@ -274,13 +274,15 @@ export function MentorHome() {
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-2">
         {/* Task Requests */}
         <Card className="rounded-2xl border bg-card shadow-sm">
-          <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-            <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
-              <BookOpen className="size-4 text-warning" />
+          <CardHeader className="px-5 py-4">
+            <div className="flex flex-row items-center gap-2.5">
+              <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
+                <BookOpen className="size-4 text-warning" />
+              </div>
+              <CardTitle className="text-base font-bold text-foreground">
+                Task Requests
+              </CardTitle>
             </div>
-            <CardTitle className="text-base font-bold text-foreground">
-              Task Requests
-            </CardTitle>
           </CardHeader>
           <CardContent className="px-5 pb-5 pt-0">
             {overviewLoading ? (

--- a/src/features/home/components/mentor/availability-card.tsx
+++ b/src/features/home/components/mentor/availability-card.tsx
@@ -26,13 +26,15 @@ export function AvailabilityCard({ expertise, isLoading }: Props) {
 
   return (
     <Card className="rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
-          <Sparkles className="size-4 text-warning" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-warning/10">
+            <Sparkles className="size-4 text-warning" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            Availability &amp; Expertise
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          Availability &amp; Expertise
-        </CardTitle>
       </CardHeader>
       <CardContent className="space-y-5 px-5 pb-5 pt-0">
         <div className="flex items-center justify-between rounded-xl border bg-muted/40 px-4 py-3">

--- a/src/features/home/components/mentor/my-igs-card.tsx
+++ b/src/features/home/components/mentor/my-igs-card.tsx
@@ -22,13 +22,15 @@ export function MyIgsCard() {
 
   return (
     <Card className="rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10">
-          <Users className="size-4 text-primary" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10">
+            <Users className="size-4 text-primary" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            My Interest Groups
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          My Interest Groups
-        </CardTitle>
       </CardHeader>
       <CardContent className="px-5 pb-5 pt-0">
         {isLoading ? (

--- a/src/features/home/components/mentor/upcoming-sessions-card.tsx
+++ b/src/features/home/components/mentor/upcoming-sessions-card.tsx
@@ -50,13 +50,15 @@ const STATUS_STYLES: Record<string, string> = {
 export function UpcomingSessionsCard({ sessions, isLoading }: Props) {
   return (
     <Card className="rounded-2xl border bg-card shadow-sm">
-      <CardHeader className="flex-row items-center gap-2.5 px-5 py-4">
-        <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10">
-          <CalendarClock className="size-4 text-primary" />
+      <CardHeader className="px-5 py-4">
+        <div className="flex flex-row items-center gap-2.5">
+          <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10">
+            <CalendarClock className="size-4 text-primary" />
+          </div>
+          <CardTitle className="text-base font-bold text-foreground">
+            Upcoming Sessions
+          </CardTitle>
         </div>
-        <CardTitle className="text-base font-bold text-foreground">
-          Upcoming Sessions
-        </CardTitle>
       </CardHeader>
       <CardContent className="px-5 pb-5 pt-0">
         {isLoading ? (

--- a/src/features/home/schemas/home.schema.ts
+++ b/src/features/home/schemas/home.schema.ts
@@ -509,7 +509,11 @@ export const CampusMemberFunnelResponseSchema = ApiResponseSchema(
 // Circle Health
 export const CampusCircleHealthItemSchema = z.object({
   circle_id: z.string(),
-  circle_name: z.string(),
+  circle_name: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((v) => (v || "").trim() || "Unnamed Circle"),
   ig_id: z.string(),
   ig_name: z.string(),
   member_count: z.number(),

--- a/src/features/projects/components/projects-tab.tsx
+++ b/src/features/projects/components/projects-tab.tsx
@@ -3,6 +3,7 @@ import { Folder, Plus } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { getApiResponseError } from "@/hooks/use-get-error";
 import {
   useAddMember,
@@ -17,7 +18,6 @@ import type { Project, ProjectFormValues } from "../schemas";
 import { ProjectCard } from "./project-card";
 import { ProjectDetailModal } from "./project-detail-modal";
 import { ProjectWizard } from "./project-wizard";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 interface ProjectsTabProps {
   muid: string;


### PR DESCRIPTION
This PR addresses layout styling consistency across the home dashboard card headers and resolves a console schema mismatch crash from the calendar sessions API.

Changes
1. Layout & Styling (Dashboard Cards)
Horizontal Header Alignment: Wrapped card header icons and titles in a flex flex-row items-center gap-2.5 container. This aligns the SVG/icon and the title side-by-side on the same line.
Note: Kept CardHeader as a grid block to prevent container size containment collapses that cause headers to vanish.
Scrollable Circle Health List: Limited the visual height of the CircleHealthCard to max-h-[196px] with overflow-y-auto so it displays exactly 3 items at a time and allows users to scroll to see the rest, matching the target UX design.
2. API Schema Validation Fixes
Nullable Fields in Calendar Schema: Updated CalendarSessionItemSchema (src/features/company-jobs/api/calendar.api.ts) to mark mentor_name and mode as .nullable().optional(). This fixes schema mismatch errors occurring when the backend API returns null values for these fields.
<img width="521" height="810" alt="image" src="https://github.com/user-attachments/assets/8a0d04f7-d02f-48d3-b083-ba1d9661885a" />
to 
<img width="516" height="537" alt="image" src="https://github.com/user-attachments/assets/e885a026-7bca-4bbf-b5c7-7d148d34ed9b" />

<img width="512" height="190" alt="image" src="https://github.com/user-attachments/assets/7b521987-f456-4a54-b895-c46895b39fae" />
to 
<img width="520" height="127" alt="image" src="https://github.com/user-attachments/assets/4a9ce42e-c9ef-4985-a135-56d9cb75ec83" />
