### PR TITLE
add Manage interest group page and define sidebar navigation configuration

### DIFF
--- a/src/app/(dashboard)/dashboard/manage-interest-groups/page.tsx
+++ b/src/app/(dashboard)/dashboard/manage-interest-groups/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { ROLES } from "@/lib/auth/roles";
+import { requireAuth } from "@/lib/auth/server";
+import { ManageInterestGroupsPageClient } from "../management/manage-interest-groups/manage-interest-groups-client";
+
+export const metadata = {
+  title: "Manage Interest Groups | Management",
+};
+
+export default async function Page() {
+  const user = await requireAuth();
+
+  const isAdmin = user.roles.includes(ROLES.ADMIN);
+  const isIgLead =
+    user.roles.includes(ROLES.IG_LEAD) ||
+    user.roles.some((r) => r.endsWith(" IGLead"));
+
+  if (!isAdmin && !isIgLead) {
+    redirect("/dashboard?unauthorized=true");
+  }
+
+  return <ManageInterestGroupsPageClient />;
+}

--- a/src/lib/auth/route-access.ts
+++ b/src/lib/auth/route-access.ts
@@ -120,6 +120,9 @@ export const routeAccessMap: Record<string, RouteConfig> = {
   "/dashboard/management/manage-interest-groups": {
     roles: [ROLES.ADMIN],
   },
+  "/dashboard/manage-interest-groups": {
+    roles: [ROLES.ADMIN, ROLES.IG_LEAD],
+  },
   "/dashboard/management/manage-roles": {
     roles: [ROLES.ADMIN],
   },

--- a/src/lib/nav-config.ts
+++ b/src/lib/nav-config.ts
@@ -15,6 +15,7 @@
 import type { LucideIcon } from "lucide-react";
 import {
   BookOpen,
+  Boxes,
   Briefcase,
   Calendar,
   CalendarDays,
@@ -228,7 +229,14 @@ export const NAV_ITEMS: readonly NavItem[] = [
     roles: [ROLES.MENTOR],
     dynamicCheck: (_, context) => !!context.isMentorVerified,
   },
-
+  {
+    id: "manage-interest-groups",
+    title: "Manage Interest Group",
+    href: "/dashboard/manage-interest-groups",
+    icon: Boxes,
+    section: "management",
+    roles: [ROLES.IG_LEAD],
+  },
   {
     id: "mentor-task-requests",
     title: "Task Requests",


### PR DESCRIPTION
This pull request introduces a new "Manage Interest Groups" page accessible to both admins and interest group leads (IG_LEADs), updates navigation to include this page for IG_LEADs, and updates route access control accordingly.

**New "Manage Interest Groups" Page and Access Control:**

* Added a new page at `/dashboard/manage-interest-groups` that checks user roles and only allows access to admins and IG_LEADs, redirecting unauthorized users. (`src/app/(dashboard)/dashboard/manage-interest-groups/page.tsx`)
* Updated route access map to include `/dashboard/manage-interest-groups` for both ADMIN and IG_LEAD roles. (`src/lib/auth/route-access.ts`)

**Navigation Updates:**

* Added a "Manage Interest Group" navigation item for IG_LEADs, using the `Boxes` icon, under the management section. (`src/lib/nav-config.ts`) [[1]](diffhunk://#diff-4befd675b2b2b508847edfd7bc2e179be60032928f26380e3d37312d73bd229aL231-R239) [[2]](diffhunk://#diff-4befd675b2b2b508847edfd7bc2e179be60032928f26380e3d37312d73bd229aR18)