### PR TITLE
fix(ig-requests): remove 10-character limit on icon field

### DIFF
--- a/.changeset/fix-ig-request-icon-url.md
+++ b/.changeset/fix-ig-request-icon-url.md
@@ -1,0 +1,5 @@
+---
+"mulearn-dashboard": patch
+---
+
+Fix icon field length limit on IG request form

--- a/src/features/ig-requests/components/ig-request-form-dialog.tsx
+++ b/src/features/ig-requests/components/ig-request-form-dialog.tsx
@@ -220,10 +220,7 @@ export function IGRequestFormDialog() {
                       <FormItem>
                         <FormLabel>Icon *</FormLabel>
                         <FormControl>
-                          <Input
-                            placeholder="Emoji or short string"
-                            {...field}
-                          />
+                          <Input {...field} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/src/features/ig-requests/schemas/ig-requests.schema.ts
+++ b/src/features/ig-requests/schemas/ig-requests.schema.ts
@@ -70,7 +70,7 @@ export const CreateIGRequestFormSchema = z.object({
   name: z.string().min(1, "Name is required").max(75),
   code: z.string().min(1, "Code is required").max(10),
   category: IGCategorySchema,
-  icon: z.string().min(1, "Icon is required").max(10),
+  icon: z.string().min(1, "Icon is required"),
   about: z.string().optional().or(z.literal("")),
   prerequisites: z.string().optional().or(z.literal("")),
   career_opportunities: z.string().optional().or(z.literal("")),


### PR DESCRIPTION
Fixes the icon field on /dashboard/company/ig-requests rejecting URLs over 10 chars. Closes #328.

- removed `.max(10)` on icon in CreateIGRequestFormSchema
- removed the emoji placeholder on the input