### PR TITLE
fix: reject whitespace-only hashtag on mentor task request form

### DIFF
--- a/src/features/mentor/tasks/schemas/index.test.ts
+++ b/src/features/mentor/tasks/schemas/index.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Mentor Task Form Schema — Unit Tests
+ *
+ * 📍 src/features/mentor/tasks/schemas/index.test.ts
+ *
+ * Regression test for the "Submit New Task" form (mentor task-request page):
+ * whitespace-only hashtags must be rejected, matching the behavior already
+ * enforced for the admin task form (src/features/tasks/schemas/tasks.schema.ts).
+ */
+
+import { describe, expect, it } from "vitest";
+import { MentorTaskFormSchema } from "./index";
+
+const validBase = {
+  title: "Design a PR Campaign",
+  karma: 100,
+  usage_count: 1,
+  description: "",
+  type: "type-id",
+  level: "level-id",
+  ig: "ig-id",
+  skill_ids: [] as string[],
+};
+
+describe("MentorTaskFormSchema — hashtag", () => {
+  it("rejects an empty hashtag", () => {
+    const result = MentorTaskFormSchema.safeParse({
+      ...validBase,
+      hashtag: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a whitespace-only hashtag", () => {
+    const result = MentorTaskFormSchema.safeParse({
+      ...validBase,
+      hashtag: "   ",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid hashtag", () => {
+    const result = MentorTaskFormSchema.safeParse({
+      ...validBase,
+      hashtag: "pr-campaign-design",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a hashtag with surrounding whitespace but real content", () => {
+    const result = MentorTaskFormSchema.safeParse({
+      ...validBase,
+      hashtag: "  pr-campaign-design  ",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/features/mentor/tasks/schemas/index.ts
+++ b/src/features/mentor/tasks/schemas/index.ts
@@ -117,7 +117,12 @@ export const MentorTaskGenericResponseSchema = ApiResponseSchema(z.unknown());
 
 // ─── Task create form schema — POST tasks/ ────────────────────────────────────
 export const MentorTaskFormSchema = z.object({
-  hashtag: z.string().min(1, "Hashtag is required"),
+  hashtag: z
+    .string()
+    .min(1, "Hashtag is required")
+    .refine((val) => val.trim().length > 0, {
+      message: "Hashtag is required",
+    }),
   title: z.string().min(1, "Title is required").max(75, "Max 75 characters"),
   karma: z.coerce
     .number()


### PR DESCRIPTION
## What
Rejects a whitespace-only value in the **Hashtag** field of the mentor "Submit New Task" / "Edit Task" form (`/dashboard/mentor/task-request`).

## Why
Fixes #326 — the field currently accepts a string of only spaces as valid, letting a task be submitted with an effectively empty hashtag. The sibling admin task form (`src/features/tasks/schemas/tasks.schema.ts`) already guards against this; this PR brings `MentorTaskFormSchema` (`src/features/mentor/tasks/schemas/index.ts`) in line with that behavior.

## Change
- `MentorTaskFormSchema.hashtag`: added a `refine` so `val.trim().length > 0` is required, in addition to the existing non-empty check.
- Added `src/features/mentor/tasks/schemas/index.test.ts` covering: empty string, whitespace-only string, a valid hashtag, and a valid hashtag with surrounding whitespace.

## Validation
- `bunx vitest run src/features/mentor/tasks/schemas/index.test.ts` — 4/4 passed
- `bun run lint` (biome) — passed
- `bun run typecheck` — passed
- Pre-commit hooks (biome, tsc, forbidden-pattern scan) passed