### PR TITLE
fix: bugs in tasks creation, mujourney sorting and ig edit invalidation bug

### DIFF
--- a/src/features/manage-ig/hooks/use-manage-ig.ts
+++ b/src/features/manage-ig/hooks/use-manage-ig.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { toast } from "sonner";
+import { igKeys } from "@/features/interest-groups";
 import { getApiResponseError } from "@/hooks/use-get-error";
 import {
   createInterestGroup as apiCreateIG,
@@ -50,9 +51,10 @@ export function useInterestGroupsAdmin() {
   const updateMutation = useMutation({
     mutationFn: ({ id, data }: { id: string; data: InterestGroupUpdate }) =>
       apiUpdateIG(id, data),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       toast.success("Interest Group updated successfully");
       queryClient.invalidateQueries({ queryKey: ["admin-interest-groups"] });
+      queryClient.invalidateQueries({ queryKey: igKeys.detail(variables.id) });
     },
     onError: (error) => {
       toast.error(
@@ -71,9 +73,10 @@ export function useInterestGroupsAdmin() {
       id: string;
       data: Partial<InterestGroupUpdate>;
     }) => apiPartialUpdateIG(id, data),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       toast.success("Interest Group partially updated");
       queryClient.invalidateQueries({ queryKey: ["admin-interest-groups"] });
+      queryClient.invalidateQueries({ queryKey: igKeys.detail(variables.id) });
     },
     onError: (error) => {
       toast.error(

--- a/src/features/mujourney/components/BecomeExpertTab.tsx
+++ b/src/features/mujourney/components/BecomeExpertTab.tsx
@@ -5,6 +5,7 @@ import { Pencil } from "lucide-react";
 import { useMemo, useState } from "react";
 import { updateInterestGroups } from "@/features/profile/api/profile.api";
 import { EditInterestGroupsModal } from "@/features/profile/components/edit-interest-groups-modal";
+import { usePublicTasks } from "@/features/tasks/hooks";
 import { mujourneyKeys } from "../hooks/query-keys";
 import type {
   GetUserLevelsResponse,
@@ -14,6 +15,8 @@ import type {
   UserLevelData,
 } from "../schemas/mujourney.schemas";
 import { LevelCard } from "./LevelCard";
+
+const FETCH_ALL_SIZE = 500;
 
 interface BecomeExpertTabProps {
   filter?: string;
@@ -70,35 +73,83 @@ export function BecomeExpertTab({
     level: { unit: "level", count: 1 } as { unit: string; count: number },
   }));
 
+  const { data: mentorData } = usePublicTasks({
+    pageIndex: 1,
+    perPage: FETCH_ALL_SIZE,
+    task_source: "ig_mentor",
+  });
+
+  const mentorTasks = useMemo<Task[]>(() => {
+    return (mentorData?.data ?? []).map((task) => ({
+      task_name: task.title,
+      task_description: task.description ?? "",
+      karma: task.karma,
+      hashtag: task.hashtag,
+      completed: false,
+      active: task.active,
+      discord_link: task.discord_link,
+      level: task.level,
+      interest_group: task.ig ? { id: task.ig, name: task.ig } : undefined,
+      submission_channel: task.channel ? { name: task.channel } : undefined,
+    }));
+  }, [mentorData]);
+
   const expertLevels = useMemo(() => {
-    if (!levelsData?.response) return [];
+    const map = new Map<string, UserLevelData>();
 
-    return levelsData.response
-      .map((level: UserLevelData) => {
-        const filteredTasks = (level.tasks || []).filter((task: Task) => {
-          const isExpertTask = (task.hashtag || "").includes("#cl-");
+    const addTask = (
+      task: Task,
+      isAlreadyExpert: boolean,
+      levelHint?: string | null,
+    ) => {
+      const isExpertTask =
+        isAlreadyExpert || (task.hashtag || "").includes("#cl-");
+      if (!isExpertTask) return;
 
-          const matchesIG = selectedIG
-            ? task.interest_group?.id === selectedIG
-            : true;
+      const matchesIG = selectedIG
+        ? task.interest_group?.id === selectedIG
+        : true;
+      if (!matchesIG) return;
 
-          if (filter === "completed")
-            return isExpertTask && matchesIG && task.completed;
-          if (filter === "incomplete")
-            return isExpertTask && matchesIG && !task.completed;
-          return isExpertTask && matchesIG;
-        });
+      if (filter === "completed" && !task.completed) return;
+      if (filter === "incomplete" && task.completed) return;
 
-        const uniqueTasks = Array.from(
+      const levelNumber = (levelHint || "").match(/\d+/)?.[0] ?? "1";
+      const levelKey = `Lvl ${levelNumber}`;
+
+      const existing = map.get(levelKey);
+      if (existing) {
+        existing.tasks = [...(existing.tasks || []), task];
+      } else {
+        map.set(levelKey, { name: levelKey, karma: 0, tasks: [task] });
+      }
+    };
+
+    (levelsData?.response ?? []).forEach((level: UserLevelData) => {
+      (level.tasks || []).forEach((task: Task) => {
+        addTask(task, false, level.name);
+      });
+    });
+    mentorTasks.forEach((task) => {
+      addTask(task, true, (task as { level?: string | null }).level);
+    });
+
+    return Array.from(map.values())
+      .map((level) => ({
+        ...level,
+        tasks: Array.from(
           new Map(
-            filteredTasks.map((task: Task) => [task.hashtag, task]),
+            (level.tasks || []).map((task: Task) => [task.hashtag, task]),
           ).values(),
-        );
-
-        return { ...level, tasks: uniqueTasks };
-      })
-      .filter((level: UserLevelData) => (level.tasks || []).length > 0);
-  }, [levelsData, selectedIG, filter]);
+        ),
+      }))
+      .filter((level) => (level.tasks || []).length > 0)
+      .sort((a, b) => {
+        const numA = parseInt(a.name.match(/\d+/)?.[0] ?? "0", 10);
+        const numB = parseInt(b.name.match(/\d+/)?.[0] ?? "0", 10);
+        return numA - numB;
+      });
+  }, [levelsData, selectedIG, filter, mentorTasks]);
 
   return (
     <div className="space-y-6">

--- a/src/features/mujourney/components/BecomeExpertTab.tsx
+++ b/src/features/mujourney/components/BecomeExpertTab.tsx
@@ -5,7 +5,7 @@ import { Pencil } from "lucide-react";
 import { useMemo, useState } from "react";
 import { updateInterestGroups } from "@/features/profile/api/profile.api";
 import { EditInterestGroupsModal } from "@/features/profile/components/edit-interest-groups-modal";
-import { usePublicTasks } from "@/features/tasks/hooks";
+import { useAllPublicTasks } from "@/features/tasks/hooks";
 import { mujourneyKeys } from "../hooks/query-keys";
 import type {
   GetUserLevelsResponse,
@@ -15,8 +15,6 @@ import type {
   UserLevelData,
 } from "../schemas/mujourney.schemas";
 import { LevelCard } from "./LevelCard";
-
-const FETCH_ALL_SIZE = 500;
 
 interface BecomeExpertTabProps {
   filter?: string;
@@ -73,26 +71,37 @@ export function BecomeExpertTab({
     level: { unit: "level", count: 1 } as { unit: string; count: number },
   }));
 
-  const { data: mentorData } = usePublicTasks({
-    pageIndex: 1,
-    perPage: FETCH_ALL_SIZE,
+  // The user's own completion state, keyed by hashtag, so mentor tasks
+  // merged in below (from the public catalog, which carries no per-user
+  // completion) can be reconciled against what the user has actually done.
+  const completionByHashtag = useMemo(() => {
+    const map = new Map<string, boolean>();
+    (levelsData?.response ?? []).forEach((level: UserLevelData) => {
+      (level.tasks || []).forEach((task: Task) => {
+        if (task.hashtag) map.set(task.hashtag, Boolean(task.completed));
+      });
+    });
+    return map;
+  }, [levelsData]);
+
+  const { data: mentorData } = useAllPublicTasks({
     task_source: "ig_mentor",
   });
 
   const mentorTasks = useMemo<Task[]>(() => {
-    return (mentorData?.data ?? []).map((task) => ({
+    return (mentorData ?? []).map((task) => ({
       task_name: task.title,
       task_description: task.description ?? "",
       karma: task.karma,
       hashtag: task.hashtag,
-      completed: false,
+      completed: completionByHashtag.get(task.hashtag) ?? false,
       active: task.active,
       discord_link: task.discord_link,
       level: task.level,
       interest_group: task.ig ? { id: task.ig, name: task.ig } : undefined,
       submission_channel: task.channel ? { name: task.channel } : undefined,
     }));
-  }, [mentorData]);
+  }, [mentorData, completionByHashtag]);
 
   const expertLevels = useMemo(() => {
     const map = new Map<string, UserLevelData>();

--- a/src/features/mujourney/components/EventsTab.tsx
+++ b/src/features/mujourney/components/EventsTab.tsx
@@ -5,7 +5,8 @@
  *
  * 📍 src/features/mujourney/components/EventsTab.tsx
  *
- * Shows event-based tasks — filtered client-side to hashtags starting with #evn
+ * Shows event-based tasks — either linked to an event (event/event_id set)
+ * or using the #evn hashtag convention — paginated client-side.
  */
 
 import { Calendar, Search, X } from "lucide-react";
@@ -15,14 +16,12 @@ import { Input } from "@/components/ui/input";
 import { StateDisplay } from "@/components/ui/state-display";
 import { LevelCard } from "@/features/mujourney/components/LevelCard";
 import type { Task, UserLevelData } from "@/features/mujourney/schemas";
-import { usePublicTasks } from "@/features/tasks/hooks";
-import type { PublicTaskListParams } from "@/features/tasks/types/tasks.types";
+import { useAllPublicTasks } from "@/features/tasks/hooks";
 import { useDebounce } from "@/hooks/use-debounce";
 
 // ─── Component ─────────────────────────────────────────────────────────
 
 const PAGE_SIZE = 20;
-const FETCH_ALL_SIZE = 500;
 
 export function EventsTab() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -30,16 +29,9 @@ export function EventsTab() {
 
   const debouncedSearch = useDebounce(searchInput, 400);
 
-  // Fetch the full task set; event tasks are filtered + paginated client-side below
-  const queryParams: PublicTaskListParams = {
-    pageIndex: 1,
-    perPage: FETCH_ALL_SIZE,
+  const { data: allTasks = [], isLoading } = useAllPublicTasks({
     search: debouncedSearch,
-  };
-
-  const { data, isLoading } = usePublicTasks(queryParams);
-
-  const allTasks = data?.data ?? [];
+  });
 
   const clearSearch = () => {
     setSearchInput("");
@@ -52,7 +44,13 @@ export function EventsTab() {
   };
 
   const eventTasks = useMemo(
-    () => allTasks.filter((task) => (task.hashtag || "").startsWith("#evn")),
+    () =>
+      allTasks.filter(
+        (task) =>
+          (task.hashtag || "").startsWith("#evn") ||
+          Boolean(task.event) ||
+          Boolean(task.event_id),
+      ),
     [allTasks],
   );
 

--- a/src/features/mujourney/components/EventsTab.tsx
+++ b/src/features/mujourney/components/EventsTab.tsx
@@ -5,7 +5,7 @@
  *
  * 📍 src/features/mujourney/components/EventsTab.tsx
  *
- * Shows event-based tasks — pre-filtered to is_event_task=true
+ * Shows event-based tasks — filtered client-side to hashtags starting with #evn
  */
 
 import { Calendar, Search, X } from "lucide-react";
@@ -21,25 +21,25 @@ import { useDebounce } from "@/hooks/use-debounce";
 
 // ─── Component ─────────────────────────────────────────────────────────
 
+const PAGE_SIZE = 20;
+const FETCH_ALL_SIZE = 500;
+
 export function EventsTab() {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchInput, setSearchInput] = useState("");
 
   const debouncedSearch = useDebounce(searchInput, 400);
 
-  // Always filter to event tasks only
+  // Fetch the full task set; event tasks are filtered + paginated client-side below
   const queryParams: PublicTaskListParams = {
-    pageIndex: currentPage,
-    perPage: 20,
+    pageIndex: 1,
+    perPage: FETCH_ALL_SIZE,
     search: debouncedSearch,
-    is_event_task: true,
   };
 
   const { data, isLoading } = usePublicTasks(queryParams);
 
-  const tasks = data?.data ?? [];
-  const pagination = data?.pagination;
-  const totalPages = pagination?.totalPages ?? 1;
+  const allTasks = data?.data ?? [];
 
   const clearSearch = () => {
     setSearchInput("");
@@ -51,12 +51,23 @@ export function EventsTab() {
     setCurrentPage(1);
   };
 
+  const eventTasks = useMemo(
+    () => allTasks.filter((task) => (task.hashtag || "").startsWith("#evn")),
+    [allTasks],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(eventTasks.length / PAGE_SIZE));
+  const pageTasks = eventTasks.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE,
+  );
+
   // ─── Group tasks by level ───────────────────────────────────────────
 
   const groupedLevels = useMemo(() => {
     const map = new Map<string, Task[]>();
 
-    tasks.forEach((task) => {
+    pageTasks.forEach((task) => {
       const levelNumber = task.level?.match(/\d+/)?.[0] ?? "1";
       const levelKey = `Lvl ${levelNumber}`;
 
@@ -93,7 +104,7 @@ export function EventsTab() {
     });
 
     return levels;
-  }, [tasks]);
+  }, [pageTasks]);
 
   // ─── Render ────────────────────────────────────────────────────────
 

--- a/src/features/mujourney/components/MuJourneyDashboard.tsx
+++ b/src/features/mujourney/components/MuJourneyDashboard.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown } from "lucide-react";
 import { useState } from "react";
-import { LearnerTasksPage } from "@/features/home/components/learner-tasks-page";
 import {
   BecomeExpertTab,
   EventsTab,
@@ -14,18 +12,6 @@ import {
   useStartLearning,
 } from "@/features/mujourney";
 import type { GetUserLevelsResponse } from "@/features/mujourney/schemas";
-import type { PublicTaskListParams } from "@/features/tasks/types/tasks.types";
-
-// ─── Others tab source options ──────────────────────────────────────────────
-
-type OthersSource = PublicTaskListParams["task_source"] | "";
-
-const OTHERS_SOURCE_OPTIONS: { label: string; value: OthersSource }[] = [
-  { label: "All Tasks", value: "" },
-  { label: "Company Tasks", value: "company" },
-  { label: "Campus Tasks", value: "campus_mentor" },
-  { label: "Mentor Tasks", value: "ig_mentor" },
-];
 
 // ─── Props ──────────────────────────────────────────────────────────────────
 
@@ -42,7 +28,6 @@ export function MuJourneyDashboard({
 }: MuJourneyDashboardProps) {
   const [activeTab, setActiveTab] = useState("start-learning");
   const [filter, setFilter] = useState("all");
-  const [othersSource, setOthersSource] = useState<OthersSource>("");
 
   const {
     data: levelsData,
@@ -60,7 +45,6 @@ export function MuJourneyDashboard({
     { id: "start-learning", label: "Start Journey" },
     { id: "become-expert", label: "Become Expert" },
     { id: "events", label: "Events" },
-    { id: "others", label: "Others" },
   ];
 
   return (
@@ -106,30 +90,6 @@ export function MuJourneyDashboard({
                 Incomplete
               </option>
             </select>
-          </div>
-        )}
-
-        {/* Others source dropdown — shown only on Others tab */}
-        {activeTab === "others" && (
-          <div className="flex items-center gap-3">
-            <span className="text-base font-medium text-foreground">Show:</span>
-            <div className="relative">
-              <select
-                id="others-source"
-                value={othersSource}
-                onChange={(e) =>
-                  setOthersSource(e.target.value as OthersSource)
-                }
-                className="appearance-none pl-4 pr-9 py-2.5 border border-border rounded-lg bg-card text-base font-medium text-card-foreground cursor-pointer hover:border-ring transition-colors outline-none focus:ring-2 focus:ring-ring"
-              >
-                {OTHERS_SOURCE_OPTIONS.map((opt) => (
-                  <option key={opt.value || "__all__"} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-              <ChevronDown className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
-            </div>
           </div>
         )}
       </div>
@@ -182,18 +142,6 @@ export function MuJourneyDashboard({
               transition={{ duration: 0.3 }}
             >
               <EventsTab />
-            </motion.div>
-          )}
-
-          {activeTab === "others" && (
-            <motion.div
-              key="others"
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: 20 }}
-              transition={{ duration: 0.3 }}
-            >
-              <LearnerTasksPage key={othersSource} taskSource={othersSource} />
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/features/mujourney/components/StartLearningTab.tsx
+++ b/src/features/mujourney/components/StartLearningTab.tsx
@@ -10,12 +10,9 @@
 
 import { useMemo } from "react";
 import { StateDisplay } from "@/components/ui/state-display";
-import { usePublicTasks } from "@/features/tasks/hooks";
+import { useAllPublicTasks } from "@/features/tasks/hooks";
 import type { GetUserLevelsResponse, Task, UserLevelData } from "../schemas";
 import { LevelCard } from "./LevelCard";
-
-// Large enough to pull the full company/campus task set in one call for client-side merge
-const FETCH_ALL_SIZE = 500;
 
 interface StartLearningTabProps {
   filter?: string;
@@ -32,33 +29,41 @@ export function StartLearningTab({
 }: StartLearningTabProps) {
   const data = levelsData;
   const levels = data?.response ?? [];
-  const { data: companyData } = usePublicTasks({
-    pageIndex: 1,
-    perPage: FETCH_ALL_SIZE,
-    task_source: "company",
-  });
-  const { data: campusData } = usePublicTasks({
-    pageIndex: 1,
-    perPage: FETCH_ALL_SIZE,
+
+  // The user's own completion state, keyed by hashtag, so tasks merged in
+  // below from the public catalog (which carries no per-user completion)
+  // can be reconciled against what the user has actually completed.
+  const completionByHashtag = useMemo(() => {
+    const map = new Map<string, boolean>();
+    levels.forEach((level: UserLevelData) => {
+      (level.tasks || []).forEach((task: Task) => {
+        if (task.hashtag) map.set(task.hashtag, Boolean(task.completed));
+      });
+    });
+    return map;
+  }, [levels]);
+
+  const { data: companyData } = useAllPublicTasks({ task_source: "company" });
+  const { data: campusData } = useAllPublicTasks({
     task_source: "campus_mentor",
   });
 
   const generalTasks = useMemo<Task[]>(() => {
-    const raw = [...(companyData?.data ?? []), ...(campusData?.data ?? [])];
+    const raw = [...(companyData ?? []), ...(campusData ?? [])];
     return raw.map((task) => ({
       task_id: task.id,
       task_name: task.title,
       task_description: task.description ?? "",
       karma: task.karma,
       hashtag: task.hashtag,
-      completed: false,
+      completed: completionByHashtag.get(task.hashtag) ?? false,
       active: task.active,
       discord_link: task.discord_link,
       level: task.level,
       interest_group: task.ig ? { name: task.ig } : undefined,
       submission_channel: task.channel ? { name: task.channel } : undefined,
     }));
-  }, [companyData, campusData]);
+  }, [companyData, campusData, completionByHashtag]);
 
   // Filter out tasks with #cl- (expert/Interest Group) or #evn (event) hashtags
   // Start Learning Tab: EXCLUDE tasks containing #cl- or starting with #evn

--- a/src/features/mujourney/components/StartLearningTab.tsx
+++ b/src/features/mujourney/components/StartLearningTab.tsx
@@ -10,8 +10,12 @@
 
 import { useMemo } from "react";
 import { StateDisplay } from "@/components/ui/state-display";
+import { usePublicTasks } from "@/features/tasks/hooks";
 import type { GetUserLevelsResponse, Task, UserLevelData } from "../schemas";
 import { LevelCard } from "./LevelCard";
+
+// Large enough to pull the full company/campus task set in one call for client-side merge
+const FETCH_ALL_SIZE = 500;
 
 interface StartLearningTabProps {
   filter?: string;
@@ -26,36 +30,76 @@ export function StartLearningTab({
   isLoading,
   error,
 }: StartLearningTabProps) {
-  // Data comes from parent
   const data = levelsData;
-
-  // Response is directly an array of levels
   const levels = data?.response ?? [];
+  const { data: companyData } = usePublicTasks({
+    pageIndex: 1,
+    perPage: FETCH_ALL_SIZE,
+    task_source: "company",
+  });
+  const { data: campusData } = usePublicTasks({
+    pageIndex: 1,
+    perPage: FETCH_ALL_SIZE,
+    task_source: "campus_mentor",
+  });
+
+  const generalTasks = useMemo<Task[]>(() => {
+    const raw = [...(companyData?.data ?? []), ...(campusData?.data ?? [])];
+    return raw.map((task) => ({
+      task_id: task.id,
+      task_name: task.title,
+      task_description: task.description ?? "",
+      karma: task.karma,
+      hashtag: task.hashtag,
+      completed: false,
+      active: task.active,
+      discord_link: task.discord_link,
+      level: task.level,
+      interest_group: task.ig ? { name: task.ig } : undefined,
+      submission_channel: task.channel ? { name: task.channel } : undefined,
+    }));
+  }, [companyData, campusData]);
 
   // Filter out tasks with #cl- (expert/Interest Group) or #evn (event) hashtags
   // Start Learning Tab: EXCLUDE tasks containing #cl- or starting with #evn
-  const foundationLevels = useMemo(
-    () =>
-      levels
-        .map((level: UserLevelData) => ({
-          ...level,
-          tasks: (level.tasks || []).filter((task: Task) => {
-            const hashtag = task.hashtag || "";
-            const isFoundationTask =
-              !hashtag.includes("#cl-") && !hashtag.startsWith("#evn");
+  const foundationLevels = useMemo(() => {
+    const map = new Map<string, UserLevelData>();
 
-            // Apply completion filter
-            if (filter === "completed") {
-              return isFoundationTask && task.completed;
-            } else if (filter === "incomplete") {
-              return isFoundationTask && !task.completed;
-            }
-            return isFoundationTask;
-          }),
-        }))
-        .filter((level: UserLevelData) => (level.tasks || []).length > 0), // Remove empty levels
-    [levels, filter],
-  );
+    const addTask = (task: Task, levelHint?: string | null) => {
+      const hashtag = task.hashtag || "";
+      const isFoundationTask =
+        !hashtag.includes("#cl-") && !hashtag.startsWith("#evn");
+      if (!isFoundationTask) return;
+
+      if (filter === "completed" && !task.completed) return;
+      if (filter === "incomplete" && task.completed) return;
+
+      const levelNumber = (levelHint || "").match(/\d+/)?.[0] ?? "1";
+      const levelKey = `Lvl ${levelNumber}`;
+
+      const existing = map.get(levelKey);
+      if (existing) {
+        existing.tasks = [...(existing.tasks || []), task];
+      } else {
+        map.set(levelKey, { name: levelKey, karma: 0, tasks: [task] });
+      }
+    };
+
+    levels.forEach((level: UserLevelData) => {
+      (level.tasks || []).forEach((task: Task) => {
+        addTask(task, level.name);
+      });
+    });
+    generalTasks.forEach((task) => {
+      addTask(task, (task as { level?: string | null }).level);
+    });
+
+    return Array.from(map.values()).sort((a, b) => {
+      const numA = parseInt(a.name.match(/\d+/)?.[0] ?? "0", 10);
+      const numB = parseInt(b.name.match(/\d+/)?.[0] ?? "0", 10);
+      return numA - numB;
+    });
+  }, [levels, filter, generalTasks]);
 
   if (isLoading) {
     return (
@@ -81,7 +125,7 @@ export function StartLearningTab({
     );
   }
 
-  if (!data?.response) {
+  if (!data?.response && generalTasks.length === 0) {
     return <StateDisplay variant="no-tasks" />;
   }
 

--- a/src/features/mujourney/components/StartLearningTab.tsx
+++ b/src/features/mujourney/components/StartLearningTab.tsx
@@ -32,8 +32,8 @@ export function StartLearningTab({
   // Response is directly an array of levels
   const levels = data?.response ?? [];
 
-  // Filter out tasks with #cl- hashtags (expert/Interest Group tasks)
-  // Start Learning Tab: EXCLUDE tasks containing #cl- in their hashtag
+  // Filter out tasks with #cl- (expert/Interest Group) or #evn (event) hashtags
+  // Start Learning Tab: EXCLUDE tasks containing #cl- or starting with #evn
   const foundationLevels = useMemo(
     () =>
       levels
@@ -41,7 +41,8 @@ export function StartLearningTab({
           ...level,
           tasks: (level.tasks || []).filter((task: Task) => {
             const hashtag = task.hashtag || "";
-            const isFoundationTask = !hashtag.includes("#cl-");
+            const isFoundationTask =
+              !hashtag.includes("#cl-") && !hashtag.startsWith("#evn");
 
             // Apply completion filter
             if (filter === "completed") {

--- a/src/features/tasks/components/task-form.tsx
+++ b/src/features/tasks/components/task-form.tsx
@@ -46,6 +46,7 @@ export default function TaskForm({
     control,
     setValue,
     watch,
+    trigger,
     formState: { errors },
     // biome-ignore lint/suspicious/noExplicitAny: API type
   } = useForm<z.input<typeof TaskFormSchema>, any, TaskFormValues>({
@@ -73,6 +74,7 @@ export default function TaskForm({
   });
 
   const hashtagValue = watch("hashtag");
+  const eventValue = watch("event");
   const _bonusKarmaValue = watch("bonus_karma");
 
   // Ensure hashtag starts with '#'
@@ -81,6 +83,11 @@ export default function TaskForm({
       setValue("hashtag", `#${hashtagValue}`);
     }
   }, [hashtagValue, setValue]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: eventValue drives revalidation but isn't read in the body
+  useEffect(() => {
+    if (hashtagValue) trigger("hashtag");
+  }, [eventValue, trigger, hashtagValue]);
 
   // Show bonus fields if bonus_karma is set or bonus_time exists
   useEffect(() => {

--- a/src/features/tasks/hooks/index.ts
+++ b/src/features/tasks/hooks/index.ts
@@ -6,6 +6,7 @@ export {
 } from "./use-task-types";
 export { usePendingTasks, useReviewTask } from "./use-task-verification";
 export {
+  useAllPublicTasks,
   useCreateTask,
   useDeleteTask,
   useDownloadTasksCsv,

--- a/src/features/tasks/hooks/use-tasks.ts
+++ b/src/features/tasks/hooks/use-tasks.ts
@@ -50,6 +50,40 @@ export const usePublicTasks = (
   return query;
 };
 
+export const useAllPublicTasks = (
+  params: Omit<PublicTaskListParams, "pageIndex" | "perPage">,
+  options?: { enabled?: boolean; perPage?: number },
+) => {
+  const perPage = options?.perPage ?? 100;
+
+  const query = useQuery({
+    queryKey: ["public-tasks-all", params, perPage],
+    queryFn: async () => {
+      const first = await fetchPublicTasks({
+        ...params,
+        pageIndex: 1,
+        perPage,
+      });
+      const totalPages = first.pagination.totalPages || 1;
+
+      if (totalPages <= 1) return first.data;
+
+      const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) =>
+          fetchPublicTasks({ ...params, pageIndex: i + 2, perPage }),
+        ),
+      );
+
+      return [first.data, ...rest.map((page) => page.data)].flat();
+    },
+    placeholderData: (prev) => prev,
+    enabled: options?.enabled,
+  });
+
+  useTaskQueryErrorToast(query.error, "Failed to load public tasks.");
+  return query;
+};
+
 export const useTaskDetail = (id: string, options?: { enabled?: boolean }) => {
   const query = useQuery({
     queryKey: ["task", id],

--- a/src/features/tasks/schemas/tasks.schema.ts
+++ b/src/features/tasks/schemas/tasks.schema.ts
@@ -35,47 +35,57 @@ export const TaskListResponseSchema = ApiResponseSchema(
 );
 
 // Form / Creation Input Schema
-export const TaskFormSchema = z.object({
-  hashtag: z
-    .string()
-    .max(75, "Max 75 characters")
-    .refine((val) => val.startsWith("#"), {
-      message: "Hashtag must start with '#'",
-    })
-    .refine((val) => val.replace(/^#/, "").trim().length > 0, {
-      message: "Hashtag is required",
-    }),
-  // 75 is the task_list.title column width, not a UX choice
-  title: z.string().min(1, "Title is required").max(75, "Max 75 characters"),
-  karma: z.coerce
-    .number()
-    .int("Karma Points must be a whole number")
-    .positive("Karma Points must be a positive number")
-    .min(10, "Karma Points must be at least 10")
-    .max(
-      9999,
-      "Karma Points cannot exceed the maximum allowed value of 9,999.",
-    ),
-  usage_count: z.coerce.number().min(1, "Mention the number of uses"),
-  active: z.boolean().default(true),
-  variable_karma: z.boolean().default(false),
-  description: z.string().min(1, "A description is required"),
-  channel_id: z.string().min(1, "Select a Channel"),
-  type_id: z.string().min(1, "Select a Type"),
-  level_id: z.string().nullable().optional(),
-  ig_id: z.string().nullable().optional(),
-  organization_id: z.string().nullable().optional(),
-  discord_link: z
-    .string()
-    .url("Invalid URL")
-    .or(z.string().length(0))
-    .nullable()
-    .optional(),
-  event: z.string().nullable().optional(),
-  bonus_time: z.string().nullable().optional(),
-  bonus_karma: z.coerce.number().default(0),
-  skill_ids: z.array(z.string()).default([]),
-});
+export const TaskFormSchema = z
+  .object({
+    hashtag: z
+      .string()
+      .max(75, "Max 75 characters")
+      .refine((val) => val.startsWith("#"), {
+        message: "Hashtag must start with '#'",
+      })
+      .refine((val) => val.replace(/^#/, "").trim().length > 0, {
+        message: "Hashtag is required",
+      }),
+    // 75 is the task_list.title column width, not a UX choice
+    title: z.string().min(1, "Title is required").max(75, "Max 75 characters"),
+    karma: z.coerce
+      .number()
+      .int("Karma Points must be a whole number")
+      .positive("Karma Points must be a positive number")
+      .min(10, "Karma Points must be at least 10")
+      .max(
+        9999,
+        "Karma Points cannot exceed the maximum allowed value of 9,999.",
+      ),
+    usage_count: z.coerce.number().min(1, "Mention the number of uses"),
+    active: z.boolean().default(true),
+    variable_karma: z.boolean().default(false),
+    description: z.string().min(1, "A description is required"),
+    channel_id: z.string().min(1, "Select a Channel"),
+    type_id: z.string().min(1, "Select a Type"),
+    level_id: z.string().nullable().optional(),
+    ig_id: z.string().nullable().optional(),
+    organization_id: z.string().nullable().optional(),
+    discord_link: z
+      .string()
+      .url("Invalid URL")
+      .or(z.string().length(0))
+      .nullable()
+      .optional(),
+    event: z.string().nullable().optional(),
+    bonus_time: z.string().nullable().optional(),
+    bonus_karma: z.coerce.number().default(0),
+    skill_ids: z.array(z.string()).default([]),
+  })
+  .superRefine((data, ctx) => {
+    if (data.event && !data.hashtag.startsWith("#evn")) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["hashtag"],
+        message: "Hashtag must start with '#evn' when an event is selected",
+      });
+    }
+  });
 
 export type TaskFormValues = z.infer<typeof TaskFormSchema>;
 


### PR DESCRIPTION
- Removed others tab in mujourney and integrated all tasks into the start learning and become expert tabs
- After editing an ig, the hook gets invalidated to provide fresh data 
- During task creation, if an event is chosen, it is mandatory for the hashtag to start with evn
- event based task should only show in events tab