### PR TITLE
fix(auth): reject whitespace-only company name on Basic Info

### DIFF
--- a/.changeset/company-name-whitespace.md
+++ b/.changeset/company-name-whitespace.md
@@ -1,0 +1,5 @@
+---
+"mulearn-dashboard": patch
+---
+
+Reject whitespace-only company names during company registration

--- a/src/features/auth/components/register-role-details.tsx
+++ b/src/features/auth/components/register-role-details.tsx
@@ -193,6 +193,7 @@ const companyDetailsSchema = z.object({
   // Basic Info
   companyName: z
     .string()
+    .trim()
     .min(1, "Company name is required")
     .max(75, "Max 75 characters"),
   companyDescription: z.string().min(1, "Description is required"),


### PR DESCRIPTION
Whitespace-only company names passed step 1 validation because `.min(1)` counts spaces. Added `.trim()` so they fail on Basic Info when you hit Next. Closes #327 
